### PR TITLE
Adding function to create contrast for bg color, modify tests

### DIFF
--- a/src/Ansi16mBrush.ts
+++ b/src/Ansi16mBrush.ts
@@ -45,6 +45,6 @@ export class Ansi16mBrush implements Brush {
     return [this.wrapAnsi16m(` ${id} `, rgb, 10), ...rest]
   }
   private wrapAnsi16m(id: string, rgb, offset: number = 0) {
-    return `\u001B[${38 + offset}2${rgb[0]}${rgb[1]}${rgb[2]}m` + id + `\u001B[${39 + offset}m`
+    return `\u001B[${38 + offset};2;${rgb[0]};${rgb[1]};${rgb[2]}m` + id + `\u001B[${39 + offset}m`
   }
 }

--- a/src/Ansi16mBrush.ts
+++ b/src/Ansi16mBrush.ts
@@ -1,4 +1,4 @@
-import { RGB, createColorsFromMap } from 'color-map'
+import {RGB, createColorsFromMap} from 'color-map'
 
 import { rainbow } from './colors'
 import { BrushOption, Brush } from './interfaces'

--- a/src/Ansi16mBrush.ts
+++ b/src/Ansi16mBrush.ts
@@ -4,11 +4,11 @@ import { rainbow } from './colors'
 import { BrushOption, Brush } from './interfaces'
 
 export class Ansi16mBrush implements Brush {
-  public color: (id: string, ...rest: any[]) => string[]
-  private count = 0
-  private colors: RGB[]
-  private map: { [index: string]: RGB } = {}
-  private option: BrushOption
+  public color: (id: string, ...rest: any[]) => string[];
+  private count = 0;
+  private colors: RGB[];
+  private map: { [index: string]: RGB } = {};
+  private option: BrushOption;
 
   constructor(option: Partial<BrushOption> = {}) {
     this.option = {
@@ -23,7 +23,7 @@ export class Ansi16mBrush implements Brush {
         index: m.index,
         rgb: [m.rgb[0], m.rgb[1] * 0.7, m.rgb[2]] as RGB
       }
-    })
+    });
 
     this.colors = createColorsFromMap(colormap, option.maxColor || 20)
 
@@ -36,12 +36,12 @@ export class Ansi16mBrush implements Brush {
     return this.map[text] = this.map[text] || this.colors[this.count++ % this.option.maxColor]
   }
   private colorAnsi16m(id: string, ...rest: string[]) {
-    const rgb = this.getRgb(id)
+    const rgb = this.getRgb(id);
     return [this.wrapAnsi16m(id, rgb), ...rest]
   }
 
   private getAnsi16mBackgroundString(id: string, ...rest: string[]) {
-    const rgb = this.getRgb(id)
+    const rgb = this.getRgb(id);
     return [this.wrapAnsi16m(` ${id} `, rgb, 10), ...rest]
   }
   private wrapAnsi16m(id: string, rgb, offset: number = 0) {

--- a/src/Ansi16mBrush.ts
+++ b/src/Ansi16mBrush.ts
@@ -1,14 +1,14 @@
-import {RGB, createColorsFromMap} from 'color-map'
+import { RGB, createColorsFromMap } from 'color-map'
 
 import { rainbow } from './colors'
 import { BrushOption, Brush } from './interfaces'
 
 export class Ansi16mBrush implements Brush {
-  public color: (id: string, ...rest: any[]) => string[];
-  private count = 0;
-  private colors: RGB[];
-  private map: { [index: string]: RGB } = {};
-  private option: BrushOption;
+  public color: (id: string, ...rest: any[]) => string[]
+  private count = 0
+  private colors: RGB[]
+  private map: { [index: string]: RGB } = {}
+  private option: BrushOption
 
   constructor(option: Partial<BrushOption> = {}) {
     this.option = {
@@ -23,7 +23,7 @@ export class Ansi16mBrush implements Brush {
         index: m.index,
         rgb: [m.rgb[0], m.rgb[1] * 0.7, m.rgb[2]] as RGB
       }
-    });
+    })
 
     this.colors = createColorsFromMap(colormap, option.maxColor || 20)
 
@@ -36,15 +36,15 @@ export class Ansi16mBrush implements Brush {
     return this.map[text] = this.map[text] || this.colors[this.count++ % this.option.maxColor]
   }
   private colorAnsi16m(id: string, ...rest: string[]) {
-    const rgb = this.getRgb(id);
+    const rgb = this.getRgb(id)
     return [this.wrapAnsi16m(id, rgb), ...rest]
   }
 
   private getAnsi16mBackgroundString(id: string, ...rest: string[]) {
-    const rgb = this.getRgb(id);
+    const rgb = this.getRgb(id)
     return [this.wrapAnsi16m(` ${id} `, rgb, 10), ...rest]
   }
   private wrapAnsi16m(id: string, rgb, offset: number = 0) {
-    return `\u001B[${38 + offset};2;${rgb[0]};${rgb[1]};${rgb[2]}m` + id + `\u001B[${39 + offset}m`
+    return `\u001B[${38 + offset}2${rgb[0]}${rgb[1]}${rgb[2]}m` + id + `\u001B[${39 + offset}m`
   }
 }

--- a/src/CSSBrush.spec.ts
+++ b/src/CSSBrush.spec.ts
@@ -4,9 +4,9 @@ import test from 'ava'
 import { CSSBrush } from './CSSBrush'
 
 test('work with null', t => {
-  const brush = new CSSBrush({ maxColor: 10 })
-  const actual = brush.color('a', null)
-  t.deepEqual(actual, ["%c a ", "padding: 2px; margin: 2px; line-height: 1.8em;background: #96005a;bother: 1px solid #76003a;color: #ffffff;", null])
+  const brush = new CSSBrush({ maxColor: 10 });
+  const actual = brush.color('a', null);
+  t.deepEqual(actual, ['%c a ', 'padding: 2px; margin: 2px; line-height: 1.8em;background: #96005a;border: 1px solid #76003a;color: #ffffff;', null])
 })
 
 test('background', t => {
@@ -17,7 +17,7 @@ test('background', t => {
     actual.push(brush.color(i.toString()))
   }
 
-  t.deepEqual(actual, [['%c 0 ', 'padding: 2px; margin: 2px; line-height: 1.8em;background: #96005a;bother: 1px solid #76003a;color: #ffffff;'], ['%c 1 ', 'padding: 2px; margin: 2px; line-height: 1.8em;background: #0000c8;bother: 1px solid #0000a8;color: #ffffff;'], ['%c 2 ', 'padding: 2px; margin: 2px; line-height: 1.8em;background: #0019ff;bother: 1px solid #0000df;color: #000000;'], ['%c 3 ', 'padding: 2px; margin: 2px; line-height: 1.8em;background: #0019ff;bother: 1px solid #0000df;color: #000000;'], ['%c 4 ', 'padding: 2px; margin: 2px; line-height: 1.8em;background: #0098ff;bother: 1px solid #0078df;color: #000000;'], ['%c 5 ', 'padding: 2px; margin: 2px; line-height: 1.8em;background: #2cff96;bother: 1px solid #0cdf76;color: #000000;'], ['%c 6 ', 'padding: 2px; margin: 2px; line-height: 1.8em;background: #97ff00;bother: 1px solid #77df00;color: #000000;'], ['%c 7 ', 'padding: 2px; margin: 2px; line-height: 1.8em;background: #ffea00;bother: 1px solid #dfca00;color: #000000;'], ['%c 8 ', 'padding: 2px; margin: 2px; line-height: 1.8em;background: #ffea00;bother: 1px solid #dfca00;color: #000000;'], ['%c 9 ', 'padding: 2px; margin: 2px; line-height: 1.8em;background: #ff6f00;bother: 1px solid #df4f00;color: #000000;'], ['%c 10 ', 'padding: 2px; margin: 2px; line-height: 1.8em;background: #96005a;bother: 1px solid #76003a;color: #ffffff;']])
+  t.deepEqual(actual, [['%c 0 ', 'padding: 2px; margin: 2px; line-height: 1.8em;background: #96005a;border: 1px solid #76003a;color: #ffffff;'], ['%c 1 ', 'padding: 2px; margin: 2px; line-height: 1.8em;background: #0000c8;border: 1px solid #0000a8;color: #ffffff;'], ['%c 2 ', 'padding: 2px; margin: 2px; line-height: 1.8em;background: #0019ff;border: 1px solid #0000df;color: #ffffff;'], ['%c 3 ', 'padding: 2px; margin: 2px; line-height: 1.8em;background: #0019ff;border: 1px solid #0000df;color: #ffffff;'], ['%c 4 ', 'padding: 2px; margin: 2px; line-height: 1.8em;background: #0098ff;border: 1px solid #0078df;color: #ff6700;'], ['%c 5 ', 'padding: 2px; margin: 2px; line-height: 1.8em;background: #2cff96;border: 1px solid #0cdf76;color: #d30069;'], ['%c 6 ', 'padding: 2px; margin: 2px; line-height: 1.8em;background: #97ff00;border: 1px solid #77df00;color: #6800ff;'], ['%c 7 ', 'padding: 2px; margin: 2px; line-height: 1.8em;background: #ffea00;border: 1px solid #dfca00;color: #0015ff;'], ['%c 8 ', 'padding: 2px; margin: 2px; line-height: 1.8em;background: #ffea00;border: 1px solid #dfca00;color: #0015ff;'], ['%c 9 ', 'padding: 2px; margin: 2px; line-height: 1.8em;background: #ff6f00;border: 1px solid #df4f00;color: #0090ff;'], ['%c 10 ', 'padding: 2px; margin: 2px; line-height: 1.8em;background: #96005a;border: 1px solid #76003a;color: #ffffff;']])
 })
 
 test('text', t => {
@@ -27,11 +27,11 @@ test('text', t => {
   for (let i = 0; i <= 10; i++) {
     actual.push(brush.color(i.toString()))
   }
-  t.deepEqual(actual, [['%c 0 ', 'padding: 2px; margin: 2px; line-height: 1.8em;background: #96005a;bother: 1px solid #76003a;color: #ffffff;'], ['%c 1 ', 'padding: 2px; margin: 2px; line-height: 1.8em;background: #0000c8;bother: 1px solid #0000a8;color: #ffffff;'], ['%c 2 ', 'padding: 2px; margin: 2px; line-height: 1.8em;background: #0019ff;bother: 1px solid #0000df;color: #000000;'], ['%c 3 ', 'padding: 2px; margin: 2px; line-height: 1.8em;background: #0019ff;bother: 1px solid #0000df;color: #000000;'], ['%c 4 ', 'padding: 2px; margin: 2px; line-height: 1.8em;background: #0098ff;bother: 1px solid #0078df;color: #000000;'], ['%c 5 ', 'padding: 2px; margin: 2px; line-height: 1.8em;background: #2cff96;bother: 1px solid #0cdf76;color: #000000;'], ['%c 6 ', 'padding: 2px; margin: 2px; line-height: 1.8em;background: #97ff00;bother: 1px solid #77df00;color: #000000;'], ['%c 7 ', 'padding: 2px; margin: 2px; line-height: 1.8em;background: #ffea00;bother: 1px solid #dfca00;color: #000000;'], ['%c 8 ', 'padding: 2px; margin: 2px; line-height: 1.8em;background: #ffea00;bother: 1px solid #dfca00;color: #000000;'], ['%c 9 ', 'padding: 2px; margin: 2px; line-height: 1.8em;background: #ff6f00;bother: 1px solid #df4f00;color: #000000;'], ['%c 10 ', 'padding: 2px; margin: 2px; line-height: 1.8em;background: #96005a;bother: 1px solid #76003a;color: #ffffff;']])
+  t.deepEqual(actual, [['%c 0 ', 'padding: 2px; margin: 2px; line-height: 1.8em;background: #96005a;border: 1px solid #76003a;color: #ffffff;'], ['%c 1 ', 'padding: 2px; margin: 2px; line-height: 1.8em;background: #0000c8;border: 1px solid #0000a8;color: #ffffff;'], ['%c 2 ', 'padding: 2px; margin: 2px; line-height: 1.8em;background: #0019ff;border: 1px solid #0000df;color: #ffffff;'], ['%c 3 ', 'padding: 2px; margin: 2px; line-height: 1.8em;background: #0019ff;border: 1px solid #0000df;color: #ffffff;'], ['%c 4 ', 'padding: 2px; margin: 2px; line-height: 1.8em;background: #0098ff;border: 1px solid #0078df;color: #ff6700;'], ['%c 5 ', 'padding: 2px; margin: 2px; line-height: 1.8em;background: #2cff96;border: 1px solid #0cdf76;color: #d30069;'], ['%c 6 ', 'padding: 2px; margin: 2px; line-height: 1.8em;background: #97ff00;border: 1px solid #77df00;color: #6800ff;'], ['%c 7 ', 'padding: 2px; margin: 2px; line-height: 1.8em;background: #ffea00;border: 1px solid #dfca00;color: #0015ff;'], ['%c 8 ', 'padding: 2px; margin: 2px; line-height: 1.8em;background: #ffea00;border: 1px solid #dfca00;color: #0015ff;'], ['%c 9 ', 'padding: 2px; margin: 2px; line-height: 1.8em;background: #ff6f00;border: 1px solid #df4f00;color: #0090ff;'], ['%c 10 ', 'padding: 2px; margin: 2px; line-height: 1.8em;background: #96005a;border: 1px solid #76003a;color: #ffffff;']])
 })
 
 test('multiple colors', t => {
   const brush = new CSSBrush()
   const actual = brush.color('myLogger', '%c SomeColored Text %c AnotherColor', 'color:blue;', 'color:red;', 'not colored')
-  t.deepEqual(actual, ['%c myLogger %c SomeColored Text %c AnotherColor', 'padding: 2px; margin: 2px; line-height: 1.8em;background: #96005a;bother: 1px solid #76003a;color: #ffffff;', 'color:blue;', 'color:red;', 'not colored'])
+  t.deepEqual(actual, ['%c myLogger %c SomeColored Text %c AnotherColor', 'padding: 2px; margin: 2px; line-height: 1.8em;background: #96005a;border: 1px solid #76003a;color: #ffffff;', 'color:blue;', 'color:red;', 'not colored'])
 })

--- a/src/CSSBrush.ts
+++ b/src/CSSBrush.ts
@@ -1,38 +1,70 @@
-import { RGB, createColorsFromMap, rgbHex } from 'color-map'
+import {RGB, createColorsFromMap, rgbHex} from 'color-map'
 
-import { rainbow } from './colors'
-import { BrushOption, Brush } from './interfaces'
+import {rainbow} from './colors'
+import {BrushOption, Brush} from './interfaces'
 
 export class CSSBrush implements Brush {
-  private count = 0
-  private colors: RGB[]
-  private map: { [index: string]: RGB } = {}
-  private option: BrushOption
+    private count = 0;
+    private colors: RGB[];
+    private map: { [index: string]: RGB } = {};
+    private option: BrushOption;
+    private gammaMap = {
+        rc: 0.2126,
+        gc: 0.7152,
+        bc: 0.0722,
+        lowc: 1 / 12.92
+    };
 
-  constructor(option: Partial<BrushOption> = {}) {
-    this.option = {
-      maxColor: option.maxColor || 20,
-      coloringText: option.coloringText || false
+    constructor(option: Partial<BrushOption> = {}) {
+        this.option = {
+            maxColor: option.maxColor || 20,
+            coloringText: option.coloringText || false
+        };
+        this.colors = createColorsFromMap(rainbow, option.maxColor || 20)
     }
-    this.colors = createColorsFromMap(rainbow, option.maxColor || 20)
-  }
 
-  color(id: string, ...rest: any[]) {
-    // TODO style (italic, bold, underscore) rotation
-    const rgb = this.getRgb(id)
-    const background = rgbHex(rgb)
-    const border = rgbHex(rgb.map(x => Math.max(0, x - 32)))
-    const color = rgb.every(x => x < 220) ? '#ffffff' : '#000000'
-    let idStr = `%c ${id} `
-    if (rest.length > 1 && typeof rest[0] === 'string' && rest[0].indexOf('%c') !== -1) {
-      idStr += rest.shift()
+    color(id: string, ...rest: any[]) {
+        // #TODO style (italic, bold, underscore) rotation
+        const rgb = this.getRgb(id);
+        const background = rgbHex(rgb);
+        const border = rgbHex(rgb.map(x => Math.max(0, x - 32)));
+        const avgLuminance = rgb[0] * this.gammaMap['rc'] + rgb[1] * this.gammaMap['gc'] + rgb[2] * this.gammaMap['bc'];
+        let color = this.getComplementary(rgb); // Setting the contrasting color as default
+        const bgLuminance = this.relativeLuminance(rgb);
+        const fgLuminance = (color === '#ffffff') ? this.relativeLuminance([255,255,255]) : this.relativeLuminance([0,0,0]);
+        const relativeL = bgLuminance > fgLuminance ? (bgLuminance + 0.05) / (fgLuminance + 0.05) : (fgLuminance + 0.05) / (bgLuminance + 0.05);
+        if (relativeL < 4.5) { // Can set the contrast ratio based on text size later.
+            color = (avgLuminance < 220) ? '#ffffff' : '#000000'; // If the relative contrast is lower than standard, we switch color to black/white
+        }
+        let idStr = `%c ${id} `;
+        if (rest.length > 1 && typeof rest[0] === 'string' && rest[0].indexOf('%c') !== -1) {
+            idStr += rest.shift()
+        }
+        return [idStr, `padding: 2px; margin: 2px; line-height: 1.8em;background: ${background};border: 1px solid ${border};color: ${color};`, ...rest]
     }
-    return [idStr, `padding: 2px; margin: 2px; line-height: 1.8em;background: ${background};bother: 1px solid ${border};color: ${color};`, ...rest]
-  }
 
-  private getRgb(text: string) {
-    // It is ok to overlep color.
-    // Not trying to be too smart about it.
-    return this.map[text] = this.map[text] || this.colors[this.count++ % this.option.maxColor]
-  }
+    private getRgb(text: string) {
+        // It is ok to overlap color.
+        // Not trying to be too smart about it.
+        return this.map[text] = this.map[text] || this.colors[this.count++ % this.option.maxColor]
+    }
+
+    private relativeLuminance(rgb: any[]) {
+        const rsrgb = rgb[0] / 255; // https://www.w3.org/TR/WCAG/#relativeluminancedef
+        const gsrgb = rgb[1] / 255;
+        const bsrgb = rgb[2] / 255;
+
+        const r = rsrgb <= 0.03928 ? rsrgb * this.gammaMap['lowc'] : Math.pow((rsrgb + 0.055) / 1.055, 2.4);
+        const g = gsrgb <= 0.03928 ? gsrgb * this.gammaMap['lowc'] : Math.pow((gsrgb + 0.055) / 1.055, 2.4);
+        const b = bsrgb <= 0.03928 ? bsrgb * this.gammaMap['lowc'] : Math.pow((bsrgb + 0.055) / 1.055, 2.4);
+
+        return r * this.gammaMap['rc'] + g * this.gammaMap['gc'] + b * this.gammaMap['bc'];
+    }
+
+    private getComplementary(rgb: any[]) {
+        const r = 255 - rgb[0];
+        const g = 255 - rgb[1];
+        const b = 255 - rgb[2];
+        return '#' + ((1 << 24) + (r << 16) + (g << 8) + b).toString(16).slice(1);
+    }
 }

--- a/src/CSSBrush.ts
+++ b/src/CSSBrush.ts
@@ -24,7 +24,7 @@ export class CSSBrush implements Brush {
   }
 
   color(id: string, ...rest: any[]) {
-    // #TODO style (italic, bold, underscore) rotation
+    // TODO style (italic, bold, underscore) rotation
     const rgb = this.getRgb(id)
     const background = rgbHex(rgb)
     const border = rgbHex(rgb.map(x => Math.max(0, x - 32)))

--- a/src/CSSBrush.ts
+++ b/src/CSSBrush.ts
@@ -1,7 +1,7 @@
-import {RGB, createColorsFromMap, rgbHex} from 'color-map'
+import { RGB, createColorsFromMap, rgbHex } from 'color-map'
 
-import {rainbow} from './colors'
-import {BrushOption, Brush} from './interfaces'
+import { rainbow } from './colors'
+import { BrushOption, Brush } from './interfaces'
 
 export class CSSBrush implements Brush {
     private count = 0;

--- a/src/CSSBrush.ts
+++ b/src/CSSBrush.ts
@@ -1,70 +1,70 @@
-import { RGB, createColorsFromMap, rgbHex } from 'color-map'
+import {RGB, createColorsFromMap, rgbHex} from 'color-map'
 
-import { rainbow } from './colors'
-import { BrushOption, Brush } from './interfaces'
+import {rainbow} from './colors'
+import {BrushOption, Brush} from './interfaces'
 
 export class CSSBrush implements Brush {
-    private count = 0;
-    private colors: RGB[];
-    private map: { [index: string]: RGB } = {};
-    private option: BrushOption;
-    private gammaMap = {
-        rc: 0.2126,
-        gc: 0.7152,
-        bc: 0.0722,
-        lowc: 1 / 12.92
+  private count = 0;
+  private colors: RGB[];
+  private map: { [index: string]: RGB } = {};
+  private option: BrushOption;
+  private gammaMap = {
+    rc: 0.2126,
+    gc: 0.7152,
+    bc: 0.0722,
+    lowc: 1 / 12.92
+  };
+
+  constructor(option: Partial<BrushOption> = {}) {
+    this.option = {
+      maxColor: option.maxColor || 20,
+      coloringText: option.coloringText || false
     };
+    this.colors = createColorsFromMap(rainbow, option.maxColor || 20)
+  }
 
-    constructor(option: Partial<BrushOption> = {}) {
-        this.option = {
-            maxColor: option.maxColor || 20,
-            coloringText: option.coloringText || false
-        };
-        this.colors = createColorsFromMap(rainbow, option.maxColor || 20)
+  color(id: string, ...rest: any[]) {
+    // #TODO style (italic, bold, underscore) rotation
+    const rgb = this.getRgb(id);
+    const background = rgbHex(rgb);
+    const border = rgbHex(rgb.map(x => Math.max(0, x - 32)));
+    const avgLuminance = rgb[0] * this.gammaMap['rc'] + rgb[1] * this.gammaMap['gc'] + rgb[2] * this.gammaMap['bc'];
+    let color = this.getComplementary(rgb); // Setting the contrasting color as default
+    const bgLuminance = this.relativeLuminance(rgb);
+    const fgLuminance = (color === '#ffffff') ? this.relativeLuminance([255, 255, 255]) : this.relativeLuminance([0, 0, 0]);
+    const relativeL = bgLuminance > fgLuminance ? (bgLuminance + 0.05) / (fgLuminance + 0.05) : (fgLuminance + 0.05) / (bgLuminance + 0.05);
+    if (relativeL < 4.5) { // Can set the contrast ratio based on text size later.
+      color = (avgLuminance < 220) ? '#ffffff' : '#000000'; // If the relative contrast is lower than standard, we switch color to black/white
     }
-
-    color(id: string, ...rest: any[]) {
-        // #TODO style (italic, bold, underscore) rotation
-        const rgb = this.getRgb(id);
-        const background = rgbHex(rgb);
-        const border = rgbHex(rgb.map(x => Math.max(0, x - 32)));
-        const avgLuminance = rgb[0] * this.gammaMap['rc'] + rgb[1] * this.gammaMap['gc'] + rgb[2] * this.gammaMap['bc'];
-        let color = this.getComplementary(rgb); // Setting the contrasting color as default
-        const bgLuminance = this.relativeLuminance(rgb);
-        const fgLuminance = (color === '#ffffff') ? this.relativeLuminance([255,255,255]) : this.relativeLuminance([0,0,0]);
-        const relativeL = bgLuminance > fgLuminance ? (bgLuminance + 0.05) / (fgLuminance + 0.05) : (fgLuminance + 0.05) / (bgLuminance + 0.05);
-        if (relativeL < 4.5) { // Can set the contrast ratio based on text size later.
-            color = (avgLuminance < 220) ? '#ffffff' : '#000000'; // If the relative contrast is lower than standard, we switch color to black/white
-        }
-        let idStr = `%c ${id} `;
-        if (rest.length > 1 && typeof rest[0] === 'string' && rest[0].indexOf('%c') !== -1) {
-            idStr += rest.shift()
-        }
-        return [idStr, `padding: 2px; margin: 2px; line-height: 1.8em;background: ${background};border: 1px solid ${border};color: ${color};`, ...rest]
+    let idStr = `%c ${id} `;
+    if (rest.length > 1 && typeof rest[0] === 'string' && rest[0].indexOf('%c') !== -1) {
+      idStr += rest.shift()
     }
+    return [idStr, `padding: 2px; margin: 2px; line-height: 1.8em;background: ${background};border: 1px solid ${border};color: ${color};`, ...rest]
+  }
 
-    private getRgb(text: string) {
-        // It is ok to overlap color.
-        // Not trying to be too smart about it.
-        return this.map[text] = this.map[text] || this.colors[this.count++ % this.option.maxColor]
-    }
+  private getRgb(text: string) {
+    // It is ok to overlap color.
+    // Not trying to be too smart about it.
+    return this.map[text] = this.map[text] || this.colors[this.count++ % this.option.maxColor]
+  }
 
-    private relativeLuminance(rgb: any[]) {
-        const rsrgb = rgb[0] / 255; // https://www.w3.org/TR/WCAG/#relativeluminancedef
-        const gsrgb = rgb[1] / 255;
-        const bsrgb = rgb[2] / 255;
+  private relativeLuminance(rgb: any[]) {
+    const rsrgb = rgb[0] / 255; // https://www.w3.org/TR/WCAG/#relativeluminancedef
+    const gsrgb = rgb[1] / 255;
+    const bsrgb = rgb[2] / 255;
 
-        const r = rsrgb <= 0.03928 ? rsrgb * this.gammaMap['lowc'] : Math.pow((rsrgb + 0.055) / 1.055, 2.4);
-        const g = gsrgb <= 0.03928 ? gsrgb * this.gammaMap['lowc'] : Math.pow((gsrgb + 0.055) / 1.055, 2.4);
-        const b = bsrgb <= 0.03928 ? bsrgb * this.gammaMap['lowc'] : Math.pow((bsrgb + 0.055) / 1.055, 2.4);
+    const r = rsrgb <= 0.03928 ? rsrgb * this.gammaMap['lowc'] : Math.pow((rsrgb + 0.055) / 1.055, 2.4);
+    const g = gsrgb <= 0.03928 ? gsrgb * this.gammaMap['lowc'] : Math.pow((gsrgb + 0.055) / 1.055, 2.4);
+    const b = bsrgb <= 0.03928 ? bsrgb * this.gammaMap['lowc'] : Math.pow((bsrgb + 0.055) / 1.055, 2.4);
 
-        return r * this.gammaMap['rc'] + g * this.gammaMap['gc'] + b * this.gammaMap['bc'];
-    }
+    return r * this.gammaMap['rc'] + g * this.gammaMap['gc'] + b * this.gammaMap['bc'];
+  }
 
-    private getComplementary(rgb: any[]) {
-        const r = 255 - rgb[0];
-        const g = 255 - rgb[1];
-        const b = 255 - rgb[2];
-        return '#' + ((1 << 24) + (r << 16) + (g << 8) + b).toString(16).slice(1);
-    }
+  private getComplementary(rgb: any[]) {
+    const r = 255 - rgb[0];
+    const g = 255 - rgb[1];
+    const b = 255 - rgb[2];
+    return rgbHex([r, g, b]);
+  }
 }

--- a/src/CSSBrush.ts
+++ b/src/CSSBrush.ts
@@ -1,42 +1,42 @@
-import {RGB, createColorsFromMap, rgbHex} from 'color-map'
+import { RGB, createColorsFromMap, rgbHex } from 'color-map'
 
-import {rainbow} from './colors'
-import {BrushOption, Brush} from './interfaces'
+import { rainbow } from './colors'
+import { BrushOption, Brush } from './interfaces'
 
 export class CSSBrush implements Brush {
-  private count = 0;
-  private colors: RGB[];
-  private map: { [index: string]: RGB } = {};
-  private option: BrushOption;
+  private count = 0
+  private colors: RGB[]
+  private map: { [index: string]: RGB } = {}
+  private option: BrushOption
   private gammaMap = {
     rc: 0.2126,
     gc: 0.7152,
     bc: 0.0722,
     lowc: 1 / 12.92
-  };
+  }
 
   constructor(option: Partial<BrushOption> = {}) {
     this.option = {
       maxColor: option.maxColor || 20,
       coloringText: option.coloringText || false
-    };
+    }
     this.colors = createColorsFromMap(rainbow, option.maxColor || 20)
   }
 
   color(id: string, ...rest: any[]) {
     // #TODO style (italic, bold, underscore) rotation
-    const rgb = this.getRgb(id);
-    const background = rgbHex(rgb);
-    const border = rgbHex(rgb.map(x => Math.max(0, x - 32)));
-    const avgLuminance = rgb[0] * this.gammaMap['rc'] + rgb[1] * this.gammaMap['gc'] + rgb[2] * this.gammaMap['bc'];
-    let color = this.getComplementary(rgb); // Setting the contrasting color as default
-    const bgLuminance = this.relativeLuminance(rgb);
-    const fgLuminance = (color === '#ffffff') ? this.relativeLuminance([255, 255, 255]) : this.relativeLuminance([0, 0, 0]);
-    const relativeL = bgLuminance > fgLuminance ? (bgLuminance + 0.05) / (fgLuminance + 0.05) : (fgLuminance + 0.05) / (bgLuminance + 0.05);
+    const rgb = this.getRgb(id)
+    const background = rgbHex(rgb)
+    const border = rgbHex(rgb.map(x => Math.max(0, x - 32)))
+    const avgLuminance = rgb[0] * this.gammaMap['rc'] + rgb[1] * this.gammaMap['gc'] + rgb[2] * this.gammaMap['bc']
+    let color = this.getComplementary(rgb) // Setting the contrasting color as default
+    const bgLuminance = this.relativeLuminance(rgb)
+    const fgLuminance = (color === '#ffffff') ? this.relativeLuminance([255, 255, 255]) : this.relativeLuminance([0, 0, 0])
+    const relativeL = bgLuminance > fgLuminance ? (bgLuminance + 0.05) / (fgLuminance + 0.05) : (fgLuminance + 0.05) / (bgLuminance + 0.05)
     if (relativeL < 4.5) { // Can set the contrast ratio based on text size later.
-      color = (avgLuminance < 220) ? '#ffffff' : '#000000'; // If the relative contrast is lower than standard, we switch color to black/white
+      color = (avgLuminance < 220) ? '#ffffff' : '#000000' // If the relative contrast is lower than standard, we switch color to black/white
     }
-    let idStr = `%c ${id} `;
+    let idStr = `%c ${id} `
     if (rest.length > 1 && typeof rest[0] === 'string' && rest[0].indexOf('%c') !== -1) {
       idStr += rest.shift()
     }
@@ -50,21 +50,21 @@ export class CSSBrush implements Brush {
   }
 
   private relativeLuminance(rgb: any[]) {
-    const rsrgb = rgb[0] / 255; // https://www.w3.org/TR/WCAG/#relativeluminancedef
-    const gsrgb = rgb[1] / 255;
-    const bsrgb = rgb[2] / 255;
+    const rsrgb = rgb[0] / 255 // https://www.w3.org/TR/WCAG/#relativeluminancedef
+    const gsrgb = rgb[1] / 255
+    const bsrgb = rgb[2] / 255
 
-    const r = rsrgb <= 0.03928 ? rsrgb * this.gammaMap['lowc'] : Math.pow((rsrgb + 0.055) / 1.055, 2.4);
-    const g = gsrgb <= 0.03928 ? gsrgb * this.gammaMap['lowc'] : Math.pow((gsrgb + 0.055) / 1.055, 2.4);
-    const b = bsrgb <= 0.03928 ? bsrgb * this.gammaMap['lowc'] : Math.pow((bsrgb + 0.055) / 1.055, 2.4);
+    const r = rsrgb <= 0.03928 ? rsrgb * this.gammaMap['lowc'] : Math.pow((rsrgb + 0.055) / 1.055, 2.4)
+    const g = gsrgb <= 0.03928 ? gsrgb * this.gammaMap['lowc'] : Math.pow((gsrgb + 0.055) / 1.055, 2.4)
+    const b = bsrgb <= 0.03928 ? bsrgb * this.gammaMap['lowc'] : Math.pow((bsrgb + 0.055) / 1.055, 2.4)
 
-    return r * this.gammaMap['rc'] + g * this.gammaMap['gc'] + b * this.gammaMap['bc'];
+    return r * this.gammaMap['rc'] + g * this.gammaMap['gc'] + b * this.gammaMap['bc']
   }
 
   private getComplementary(rgb: any[]) {
-    const r = 255 - rgb[0];
-    const g = 255 - rgb[1];
-    const b = 255 - rgb[2];
-    return rgbHex([r, g, b]);
+    const r = 255 - rgb[0]
+    const g = 255 - rgb[1]
+    const b = 255 - rgb[2]
+    return rgbHex([r, g, b])
   }
 }


### PR DESCRIPTION
This PR includes:

- Creating a function to generate complementary colors
- Compare background and foreground to have minimum contrast ratio. IF not, switch to either black/white.
- Modify tests based on these changes
- Minor spelling fix 

fixes #4 